### PR TITLE
Add L1SLOAD Precompile

### DIFF
--- a/crates/precompile/src/l1sload.rs
+++ b/crates/precompile/src/l1sload.rs
@@ -1,0 +1,151 @@
+use crate::{Error, Precompile, PrecompileResult, PrecompileWithAddress};
+use revm_primitives::{Address, Bytes, PrecompileOutput, B256};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+pub const L1SLOAD: PrecompileWithAddress = PrecompileWithAddress(
+    crate::u64_to_address(0x10001),
+    Precompile::Standard(l1sload_run),
+);
+
+/// Gas constants for L1SLOAD precompile
+pub const L1SLOAD_FIXED_GAS: u64 = 2000;
+pub const L1SLOAD_PER_LOAD_GAS: u64 = 2000;
+
+/// Expected input length: 20 bytes (address) + 32 bytes (storage key) + 32 bytes (block number) = 84 bytes
+pub const EXPECTED_INPUT_LENGTH: usize = 84;
+
+/// In-memory cache for L1 storage values
+static L1_STORAGE_CACHE: LazyLock<Mutex<HashMap<(Address, B256, B256), B256>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Set a value in the L1 storage cache
+pub fn set_l1_storage_value(
+    contract_address: Address,
+    storage_key: B256,
+    block_number: B256,
+    value: B256,
+) {
+    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
+        cache.insert((contract_address, storage_key, block_number), value);
+    }
+}
+
+/// Get a value from the L1 storage cache
+fn get_l1_storage_value(
+    contract_address: Address,
+    storage_key: B256,
+    block_number: B256,
+) -> Option<B256> {
+    if let Ok(cache) = L1_STORAGE_CACHE.lock() {
+        cache
+            .get(&(contract_address, storage_key, block_number))
+            .copied()
+    } else {
+        None
+    }
+}
+
+/// L1SLOAD precompile - read storage values from L1 contracts (RIP-7728).
+///
+/// The input to the L1SLOAD precompile consists of:
+/// - [0: 19] (20 bytes)  - address: The L1 contract address
+/// - [20: 51] (32 bytes) - storageKey: The storage key to read
+/// - [52: 83] (32 bytes) - blockNumber: The L1 block number to read from
+///
+/// Output: Storage value (32 bytes)
+pub fn l1sload_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    // Check gas limit
+    let gas_used = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+    if gas_used > gas_limit {
+        return Err(Error::OutOfGas.into());
+    }
+
+    // Validate input length
+    if input.len() != EXPECTED_INPUT_LENGTH {
+        return Err(Error::Other("Invalid input length".into()).into());
+    }
+
+    // Parse input parameters
+    let contract_address = Address::from_slice(&input[0..20]);
+    let storage_key = B256::from_slice(&input[20..52]);
+    let block_number = B256::from_slice(&input[52..84]);
+
+    // Get cached L1 storage value
+    let storage_value = get_l1_storage_value(contract_address, storage_key, block_number);
+
+    match storage_value {
+        Some(value) => {
+            // Convert storage value to output bytes (32 bytes)
+            let mut output = [0u8; 32];
+            output.copy_from_slice(value.as_slice());
+            Ok(PrecompileOutput::new(gas_used, Bytes::from(output)))
+        }
+        None => {
+            // Return zero value if no cached data found
+            let output = [0u8; 32];
+            Ok(PrecompileOutput::new(gas_used, Bytes::from(output)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_l1sload_invalid_input_length() {
+        let short_input = Bytes::from(vec![0u8; 80]); // Too short
+        let result = l1sload_run(&short_input, 1000);
+        assert!(result.is_err());
+
+        let long_input = Bytes::from(vec![0u8; 100]); // Too long
+        let result = l1sload_run(&long_input, 1000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_l1sload_valid_input() {
+        let mut input = vec![0u8; EXPECTED_INPUT_LENGTH];
+
+        // Set contract address (20 bytes)
+        input[0..20].copy_from_slice(&[1u8; 20]);
+
+        // Set storage key (32 bytes)
+        input[20..52].copy_from_slice(&[2u8; 32]);
+
+        // Set block number (32 bytes)
+        input[52..84].copy_from_slice(&[3u8; 32]);
+
+        let result = l1sload_run(&Bytes::from(input), 1000);
+        assert!(result.is_ok());
+
+        let output = result.unwrap();
+        assert_eq!(output.gas_used, L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS);
+        assert_eq!(output.bytes.len(), 32);
+    }
+
+    #[test]
+    fn test_l1sload_out_of_gas() {
+        let input = Bytes::from(vec![0u8; EXPECTED_INPUT_LENGTH]);
+        let result = l1sload_run(&input, 50); // Not enough gas
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cache_functionality() {
+        let address = Address::from_slice(&[1u8; 20]);
+        let key = B256::from_slice(&[2u8; 32]);
+        let block = B256::from_slice(&[3u8; 32]);
+        let value = B256::from_slice(&[5u8; 32]);
+
+        // Initially no data
+        assert!(get_l1_storage_value(address, key, block).is_none());
+
+        // Set data
+        set_l1_storage_value(address, key, block, value);
+
+        // Now data exists
+        assert_eq!(get_l1_storage_value(address, key, block), Some(value));
+    }
+}

--- a/crates/precompile/src/l1sload.rs
+++ b/crates/precompile/src/l1sload.rs
@@ -31,6 +31,12 @@ pub fn set_l1_storage_value(
     }
 }
 
+pub fn clear_l1_storage_cache() {
+    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
+        cache.clear();
+    }
+}
+
 /// Get a value from the L1 storage cache
 fn get_l1_storage_value(
     contract_address: Address,
@@ -43,12 +49,6 @@ fn get_l1_storage_value(
             .copied()
     } else {
         None
-    }
-}
-
-pub fn clear_l1_storage_cache() {
-    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
-        cache.clear();
     }
 }
 

--- a/crates/precompile/src/l1sload.rs
+++ b/crates/precompile/src/l1sload.rs
@@ -46,6 +46,12 @@ fn get_l1_storage_value(
     }
 }
 
+pub fn clear_l1_storage_cache() {
+    if let Ok(mut cache) = L1_STORAGE_CACHE.lock() {
+        cache.clear();
+    }
+}
+
 /// L1SLOAD precompile - read storage values from L1 contracts (RIP-7728).
 ///
 /// The input to the L1SLOAD precompile consists of:
@@ -82,9 +88,8 @@ pub fn l1sload_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
             Ok(PrecompileOutput::new(gas_used, Bytes::from(output)))
         }
         None => {
-            // Return zero value if no cached data found
-            let output = [0u8; 32];
-            Ok(PrecompileOutput::new(gas_used, Bytes::from(output)))
+            // Return error if no cached data found
+            Err(Error::Other("L1 storage value not found in cache".into()).into())
         }
     }
 }
@@ -93,59 +98,154 @@ pub fn l1sload_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_l1sload_invalid_input_length() {
-        let short_input = Bytes::from(vec![0u8; 80]); // Too short
-        let result = l1sload_run(&short_input, 1000);
-        assert!(result.is_err());
+    const TEST_ADDRESS: [u8; 20] = [1u8; 20];
+    const TEST_STORAGE_KEY: [u8; 32] = [2u8; 32];
+    const TEST_BLOCK_NUMBER: [u8; 32] = [3u8; 32];
+    const TEST_STORAGE_VALUE: [u8; 32] = [5u8; 32];
+    const SUFFICIENT_GAS: u64 = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+    const INSUFFICIENT_GAS: u64 = SUFFICIENT_GAS - 1;
 
-        let long_input = Bytes::from(vec![0u8; 100]); // Too long
-        let result = l1sload_run(&long_input, 1000);
-        assert!(result.is_err());
+    /// Helper function to create test input with predefined test data
+    fn create_test_input() -> Vec<u8> {
+        let mut input = vec![0u8; EXPECTED_INPUT_LENGTH];
+        input[0..20].copy_from_slice(&TEST_ADDRESS);
+        input[20..52].copy_from_slice(&TEST_STORAGE_KEY);
+        input[52..84].copy_from_slice(&TEST_BLOCK_NUMBER);
+        input
+    }
+
+    /// Helper function to setup storage cache with test data
+    fn setup_test_storage() -> (Address, B256, B256, B256) {
+        let address = Address::from(TEST_ADDRESS);
+        let key = B256::from(TEST_STORAGE_KEY);
+        let block = B256::from(TEST_BLOCK_NUMBER);
+        let value = B256::from(TEST_STORAGE_VALUE);
+
+        set_l1_storage_value(address, key, block, value);
+        (address, key, block, value)
     }
 
     #[test]
-    fn test_l1sload_valid_input() {
-        let mut input = vec![0u8; EXPECTED_INPUT_LENGTH];
+    fn test_l1sload_rejects_invalid_input_lengths() {
+        clear_l1_storage_cache();
 
-        // Set contract address (20 bytes)
-        input[0..20].copy_from_slice(&[1u8; 20]);
+        // Test input too short
+        let short_input = Bytes::from(vec![0u8; 80]);
+        let result = l1sload_run(&short_input, SUFFICIENT_GAS);
+        assert!(result.is_err(), "Should reject too short input");
 
-        // Set storage key (32 bytes)
-        input[20..52].copy_from_slice(&[2u8; 32]);
+        // Test input too long
+        let long_input = Bytes::from(vec![0u8; 100]);
+        let result = l1sload_run(&long_input, SUFFICIENT_GAS);
+        assert!(result.is_err(), "Should reject too long input");
+    }
 
-        // Set block number (32 bytes)
-        input[52..84].copy_from_slice(&[3u8; 32]);
+    #[test]
+    fn test_l1sload_fails_without_cached_storage() {
+        clear_l1_storage_cache();
 
-        let result = l1sload_run(&Bytes::from(input), 1000);
-        assert!(result.is_ok());
+        let input = create_test_input();
+        let result = l1sload_run(&Bytes::from(input), SUFFICIENT_GAS);
+
+        assert!(
+            result.is_err(),
+            "Should fail when storage value is not cached"
+        );
+    }
+
+    #[test]
+    fn test_l1sload_succeeds_with_cached_storage() {
+        clear_l1_storage_cache();
+
+        // Setup test data and cache
+        let (_, _, _, expected_value) = setup_test_storage();
+        let input = create_test_input();
+
+        let result = l1sload_run(&Bytes::from(input), SUFFICIENT_GAS);
+        assert!(
+            result.is_ok(),
+            "Should succeed when storage value is cached"
+        );
 
         let output = result.unwrap();
-        assert_eq!(output.gas_used, L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS);
-        assert_eq!(output.bytes.len(), 32);
+
+        // Verify gas usage
+        let expected_gas = L1SLOAD_FIXED_GAS + L1SLOAD_PER_LOAD_GAS;
+        assert_eq!(
+            output.gas_used, expected_gas,
+            "Gas usage should be fixed cost + per-load cost"
+        );
+
+        // Verify output length
+        assert_eq!(output.bytes.len(), 32, "Output should be exactly 32 bytes");
+
+        // Verify output content matches stored value
+        assert_eq!(
+            output.bytes.as_ref(),
+            &expected_value.0,
+            "Output should match the cached storage value"
+        );
     }
 
     #[test]
-    fn test_l1sload_out_of_gas() {
+    fn test_l1sload_fails_with_insufficient_gas() {
+        clear_l1_storage_cache();
+
         let input = Bytes::from(vec![0u8; EXPECTED_INPUT_LENGTH]);
-        let result = l1sload_run(&input, 50); // Not enough gas
-        assert!(result.is_err());
+        let result = l1sload_run(&input, INSUFFICIENT_GAS);
+
+        assert!(
+            result.is_err(),
+            "Should fail when gas limit is insufficient"
+        );
     }
 
     #[test]
-    fn test_cache_functionality() {
-        let address = Address::from_slice(&[1u8; 20]);
-        let key = B256::from_slice(&[2u8; 32]);
-        let block = B256::from_slice(&[3u8; 32]);
-        let value = B256::from_slice(&[5u8; 32]);
+    fn test_storage_cache_operations() {
+        clear_l1_storage_cache();
 
-        // Initially no data
-        assert!(get_l1_storage_value(address, key, block).is_none());
+        let address = Address::from(TEST_ADDRESS);
+        let key = B256::from(TEST_STORAGE_KEY);
+        let block = B256::from(TEST_BLOCK_NUMBER);
+        let value = B256::from(TEST_STORAGE_VALUE);
 
-        // Set data
+        // Verify cache is initially empty
+        assert!(
+            get_l1_storage_value(address, key, block).is_none(),
+            "Cache should be empty initially"
+        );
+
         set_l1_storage_value(address, key, block, value);
+        assert_eq!(
+            get_l1_storage_value(address, key, block),
+            Some(value),
+            "Should retrieve the cached value"
+        );
+    }
 
-        // Now data exists
-        assert_eq!(get_l1_storage_value(address, key, block), Some(value));
+    #[test]
+    fn test_cache_key_uniqueness() {
+        clear_l1_storage_cache();
+
+        let address1 = Address::from([1u8; 20]);
+        let address2 = Address::from([2u8; 20]);
+        let key1 = B256::from([1u8; 32]);
+        let key2 = B256::from([2u8; 32]);
+        let block1 = B256::from([1u8; 32]);
+        let block2 = B256::from([2u8; 32]);
+        let value1 = B256::from([10u8; 32]);
+        let value2 = B256::from([20u8; 32]);
+
+        // Set different values for different cache keys
+        set_l1_storage_value(address1, key1, block1, value1);
+        set_l1_storage_value(address2, key2, block2, value2);
+
+        // Verify each key returns its correct value
+        assert_eq!(get_l1_storage_value(address1, key1, block1), Some(value1));
+        assert_eq!(get_l1_storage_value(address2, key2, block2), Some(value2));
+
+        // Verify non-existent combinations return None
+        assert!(get_l1_storage_value(address1, key2, block1).is_none());
+        assert!(get_l1_storage_value(address2, key1, block2).is_none());
     }
 }

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -17,6 +17,7 @@ pub mod hash;
 pub mod identity;
 #[cfg(any(feature = "c-kzg", feature = "kzg-rs"))]
 pub mod kzg_point_evaluation;
+pub mod l1sload;
 pub mod modexp;
 pub mod secp256k1;
 #[cfg(feature = "secp256r1")]
@@ -25,6 +26,7 @@ pub mod utilities;
 pub mod zk_op;
 
 pub use fatal_precompile::fatal_precompile;
+pub use l1sload::{set_l1_storage_value, L1SLOAD};
 
 #[cfg(all(feature = "c-kzg", feature = "kzg-rs"))]
 // silence kzg-rs lint as c-kzg will be used as default if both are enabled.
@@ -175,6 +177,10 @@ impl Precompiles {
                 precompiles.extend(bls12_381::precompiles());
                 precompiles
             };
+
+            // Add L1SLOAD precompile (RIP-7728)
+            let mut precompiles = precompiles;
+            precompiles.extend([l1sload::L1SLOAD]);
 
             Box::new(precompiles)
         })


### PR DESCRIPTION
L1SLOAD precompile which allows L2s to read values from L1. The precompile takes L1 contract address, storage key and block number as the input and outputs the storage value.

For reference, here is the [existing implementation in the Nethermind client](https://github.com/NethermindEth/nethermind/blob/8603abbad1ecb49ab9b3a2dcdd1d7284e8fa12a2/src/Nethermind/Nethermind.Evm.Precompiles/L1SloadPrecompile.cs#L29) for L1SLOAD.

The major difference between the implementation in NMC and REVM is that the latter does not use any external L1 endpoint to fetch the L1 values, but instead it uses a cache to store all the values and simply returns those values when queried. Therefore before running the REVM L1SLOAD precompile, the values have to be populated in the cache externally.